### PR TITLE
Update `<Select/>` in order to use the background tokens for `<OptionList/>`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@inubekit/button": "^4.2.0",
-    "@inubekit/foundations": "^2.14.0",
+    "@inubekit/foundations": "^2.15.0",
     "@inubekit/icon": "^1.6.0",
     "@inubekit/label": "^2.3.0",
     "@inubekit/stack": "2.2.0",

--- a/src/Select/OptionList/styles.js
+++ b/src/Select/OptionList/styles.js
@@ -12,13 +12,21 @@ const StyledOptionList = styled.ul`
   border-radius: 4px;
   background: ${({ theme }) => {
     return (
-      theme?.input?.background?.color?.regular ||
-      inube.input.background.color.regular
+      theme?.input?.optionList?.background?.expanded ||
+      inube.input.optionList.background.expanded
     );
   }};
   box-shadow:
     0px 1px 2px rgba(0, 0, 0, 0.3),
     0px 2px 6px 2px rgba(0, 0, 0, 0.15);
+  & > li:hover {
+    background: ${({ theme }) => {
+      return (
+        theme?.input?.optionList?.background?.selected ||
+        inube.input.optionList.background.selected
+      );
+    }};
+  }
 `;
 
 export { StyledOptionList };


### PR DESCRIPTION
This pull request updates the `<Select/>` component to utilize the new background tokens for the `<OptionList/>` component. This change ensures consistency in styling and improves the visual coherence of the dropdown options.