### PR TITLE
Add `readOnly` Prop to Control Typing in Inner TextField

### DIFF
--- a/src/Select/OptionList/index.tsx
+++ b/src/Select/OptionList/index.tsx
@@ -5,10 +5,11 @@ interface IOptionList {
   children: JSX.Element[];
   onOptionClick: (value: string) => void;
   options: IOption[];
+  maxItems?: number;
 }
 
 const OptionList = (props: IOptionList) => {
-  const { children, onOptionClick, options } = props;
+  const { children, onOptionClick, options, maxItems } = props;
 
   const interceptOnClick = (event: React.ChangeEvent<HTMLInputElement>) => {
     try {
@@ -26,7 +27,13 @@ const OptionList = (props: IOptionList) => {
   };
 
   return (
-    <StyledOptionList onClick={interceptOnClick}>{children}</StyledOptionList>
+    <StyledOptionList
+      maxItems={maxItems}
+      totalOptions={options.length}
+      onClick={interceptOnClick}
+    >
+      {children}
+    </StyledOptionList>
   );
 };
 

--- a/src/Select/OptionList/styles.js
+++ b/src/Select/OptionList/styles.js
@@ -19,6 +19,36 @@ const StyledOptionList = styled.ul`
   box-shadow:
     0px 1px 2px rgba(0, 0, 0, 0.3),
     0px 2px 6px 2px rgba(0, 0, 0, 0.15);
+
+  max-height: ${({ maxItems }) => (maxItems ? `${maxItems * 46}px` : "auto")};
+  overflow-y: ${({ maxItems, totalOptions }) =>
+    maxItems && totalOptions > maxItems ? "auto" : "hidden"};
+
+  &::-webkit-scrollbar {
+    width: 6px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease-in-out;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.3);
+    border-radius: 8px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease-in-out;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &:hover::-webkit-scrollbar,
+  &:hover::-webkit-scrollbar-thumb {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   & > li:hover {
     background: ${({ theme }) => {
       return (

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -3,55 +3,83 @@ import { useState, useRef, useEffect } from "react";
 import { ISelectSize } from "./props";
 import { SelectUI } from "./interface";
 
-interface ISelect {
-  label?: string;
-  name: string;
-  id?: string;
-  placeholder?: string;
-  disabled?: boolean;
-  value: string;
-  required?: boolean;
-  invalid?: boolean;
-  message?: string;
-  size?: ISelectSize;
-  fullwidth?: boolean;
-  options: IOption[];
-  onChange: (name: string, value: string) => void;
-  onFocus?: (event: FocusEvent) => void;
-  onBlur?: (event: FocusEvent) => void;
-  onClick?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-}
-
 interface IOption {
   id: string;
   label: string;
   value: string;
 }
 
+interface ISelect {
+  disabled?: boolean;
+  fullwidth?: boolean;
+  id?: string;
+  invalid?: boolean;
+  label?: string;
+  maxItems?: number;
+  message?: string;
+  name: string;
+  onBlur?: (event: FocusEvent) => void;
+  onChange: (name: string, value: string) => void;
+  onClick?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus?: (event: FocusEvent) => void;
+  options: IOption[];
+  placeholder?: string;
+  readonly?: boolean;
+  required?: boolean;
+  size?: ISelectSize;
+  value: string;
+}
+
 const Select = (props: ISelect) => {
   const {
-    label,
-    name,
-    id,
-    placeholder,
     disabled = false,
-    value,
-    required = false,
-    invalid = false,
-    message,
-    size = "wide",
     fullwidth = false,
-    options,
+    id,
+    invalid = false,
+    label,
+    maxItems = 5,
+    message,
+    name,
     onBlur,
-    onFocus,
     onChange,
     onClick,
+    onFocus,
+    options,
+    placeholder,
+    readonly = true,
+    required = false,
+    size = "wide",
+    value,
   } = props;
 
-  const [focused, setFocused] = useState(false);
   const [displayList, setDisplayList] = useState(false);
+  const [focused, setFocused] = useState(false);
 
   const selectRef = useRef<{ contains: (e: EventTarget) => EventTarget }>(null);
+
+  function handleClear() {
+    onChange(name, "");
+  }
+
+  function handleClick(event: React.ChangeEvent<HTMLInputElement>) {
+    setDisplayList(!displayList);
+    if (disabled) return;
+    try {
+      onClick && onClick(event);
+    } catch (error) {
+      console.error(`Error when clicking over select. ${error}`);
+    }
+  }
+
+  function handleDocumentClick(event: MouseEvent) {
+    if (
+      selectRef.current &&
+      event.target &&
+      !selectRef.current.contains(event.target)
+    ) {
+      setDisplayList(false);
+    }
+  }
 
   function handleFocusAndBlur(event: FocusEvent) {
     try {
@@ -69,13 +97,12 @@ const Select = (props: ISelect) => {
     }
   }
 
-  function handleDocumentClick(event: MouseEvent) {
-    if (
-      selectRef.current &&
-      event.target &&
-      !selectRef.current.contains(event.target)
-    ) {
-      setDisplayList(false);
+  function handleOptionClick(value: string) {
+    setDisplayList(false);
+    try {
+      onChange && onChange(name, value);
+    } catch (error) {
+      console.error(`Error when changing value using callback. ${error}`);
     }
   }
 
@@ -86,52 +113,31 @@ const Select = (props: ISelect) => {
     };
   }, []);
 
-  function handleOptionClick(value: string) {
-    setDisplayList(false);
-    try {
-      onChange && onChange(name, value);
-    } catch (error) {
-      console.error(`Error when changing value using callback. ${error}`);
-    }
-  }
-
-  function handleClick(event: React.ChangeEvent<HTMLInputElement>) {
-    setDisplayList(!displayList);
-    if (disabled) return;
-    try {
-      onClick && onClick(event);
-    } catch (error) {
-      console.error(`Error when clicking over select. ${error}`);
-    }
-  }
-
-  function handleClear() {
-    onChange(name, "");
-  }
-
   return (
     <SelectUI
       ref={selectRef}
-      label={label}
-      name={name}
-      id={id}
-      placeholder={placeholder}
       disabled={disabled}
-      value={value}
-      required={required}
-      size={size}
-      invalid={invalid}
-      message={message}
-      fullwidth={fullwidth}
+      displayList={displayList}
       focused={focused}
-      options={options}
-      onFocus={handleFocusAndBlur}
+      fullwidth={fullwidth}
+      handleClear={handleClear}
+      id={id}
+      invalid={invalid}
+      label={label}
+      maxItems={maxItems}
+      message={message}
+      name={name}
       onBlur={handleFocusAndBlur}
       onChange={onChange}
       onClick={handleClick}
-      displayList={displayList}
+      onFocus={handleFocusAndBlur}
       onOptionClick={handleOptionClick}
-      handleClear={handleClear}
+      options={options}
+      placeholder={placeholder}
+      required={required}
+      size={size}
+      value={value}
+      readOnly={readonly}
     />
   );
 };

--- a/src/Select/interface.tsx
+++ b/src/Select/interface.tsx
@@ -1,36 +1,41 @@
 import { forwardRef, useContext } from "react";
 
 import {
-  MdOutlineError,
   MdOutlineCancel,
   MdOutlineChevronRight,
+  MdOutlineError,
 } from "react-icons/md";
 
-import { ITextAppearance, Text } from "@inubekit/text";
 import { Icon } from "@inubekit/icon";
 import { Label } from "@inubekit/label";
 import { Stack } from "@inubekit/stack";
+import { Text, ITextAppearance } from "@inubekit/text";
 
 import { OptionList } from "./OptionList";
 import { OptionItem } from "./OptionItem";
-
-import { ISelectSize } from "./props";
 import { IOption, ISelect } from ".";
-
+import { ISelectSize } from "./props";
 import {
   StyledContainer,
-  StyledInputContainer,
   StyledInput,
+  StyledInputContainer,
   StyledChevron,
 } from "./styles";
+
 import { ThemeContext } from "styled-components";
 import { inube } from "@inubekit/foundations";
 
+interface IMessage {
+  message: ISelect["message"];
+}
+
 interface ISelectInterface extends ISelect {
-  focused?: boolean;
   displayList: boolean;
-  onOptionClick: (value: string) => void;
+  focused?: boolean;
   handleClear: () => void;
+  maxItems: number;
+  onOptionClick: (value: string) => void;
+  readOnly: boolean;
 }
 
 const getTypo = (size: ISelectSize) => {
@@ -46,10 +51,6 @@ function getOptionLabel(options: IOption[], value: string) {
     return option.label;
   }
   return "";
-}
-
-interface IMessage {
-  message: ISelect["message"];
 }
 
 const Message = (props: IMessage) => {
@@ -79,26 +80,28 @@ const Message = (props: IMessage) => {
 
 const SelectUI = forwardRef((props: ISelectInterface, ref) => {
   const {
-    label,
-    name,
-    id,
-    placeholder,
+    displayList,
     disabled,
-    required,
+    focused,
+    fullwidth,
+    handleClear,
+    id,
     invalid,
+    label,
+    maxItems,
     message,
+    name,
+    onBlur,
+    onChange,
+    onClick,
+    onFocus,
+    onOptionClick,
+    options,
+    placeholder,
+    readOnly,
+    required,
     size,
     value,
-    fullwidth,
-    options,
-    focused,
-    onFocus,
-    onBlur,
-    onClick,
-    onChange,
-    onOptionClick,
-    displayList,
-    handleClear,
   } = props;
 
   const theme: typeof inube = useContext(ThemeContext);
@@ -161,7 +164,7 @@ const SelectUI = forwardRef((props: ISelectInterface, ref) => {
           onBlur={onBlur}
           onChange={onChange}
           onClick={onClick}
-          readOnly
+          readOnly={readOnly}
         />
         <Stack direction="row" gap="8px" alignItems="center">
           {value && !disabled && (
@@ -186,7 +189,11 @@ const SelectUI = forwardRef((props: ISelectInterface, ref) => {
 
       {invalid && <Message message={message} />}
       {displayList && !disabled && (
-        <OptionList onOptionClick={onOptionClick} options={options}>
+        <OptionList
+          maxItems={maxItems}
+          onOptionClick={onOptionClick}
+          options={options}
+        >
           {options.map((optionItem) => (
             <OptionItem
               key={optionItem.id}

--- a/src/Select/props.ts
+++ b/src/Select/props.ts
@@ -14,19 +14,6 @@ const parameters = {
 };
 
 const props = {
-  label: {
-    description: "prompts the user what value to enter",
-  },
-  name: {
-    description: "name of the input element",
-  },
-  id: {
-    description:
-      "uniquely identifies the **Textfield Component**, it will also allow the **label element** to be connected to the **input element** through the htmlFor of the label",
-  },
-  placeholder: {
-    description: "text to display in the text field whenever it is empty",
-  },
   disabled: {
     description:
       "sets the field as to appear disabled, users will not be able to interact with the text field",
@@ -34,19 +21,15 @@ const props = {
       defaultValue: { summary: false },
     },
   },
-  value: {
-    description:
-      "string value that should be controlled by the controlling parent.",
-  },
-  onChange: {
-    description:
-      "allows you to control what to do when the user changes the value of the component",
-  },
-  required: {
-    description: "defines if the field is required or not",
+  fullwidth: {
+    description: "option to fit field width to its parent width",
     table: {
       defaultValue: { summary: false },
     },
+  },
+  id: {
+    description:
+      "uniquely identifies the **Textfield Component**, it will also allow the **label element** to be connected to the **input element** through the htmlFor of the label",
   },
   invalid: {
     description: "defines if the field is required or not",
@@ -57,28 +40,59 @@ const props = {
   invalidMessage: {
     description: "show when the field is validated and there is an error",
   },
-  size: {
-    options: sizes,
-    control: { type: "select" },
-    description: "defines the size of the component",
+  label: {
+    description: "prompts the user what value to enter",
   },
-  fullwidth: {
-    description: "option to fit field width to its parent width",
+  maxItems: {
+    description:
+      "defines the maximum number of items to display in the dropdown list before showing a scrollbar",
     table: {
-      defaultValue: { summary: false },
+      defaultValue: { summary: 5 },
     },
   },
-  onFocus: {
-    description:
-      "allows you to control what to do when the onfocus event occurs.",
+  name: {
+    description: "name of the input element",
   },
   onBlur: {
     description:
       "allows you to control what to do when the onblur event occurs.",
   },
+  onChange: {
+    description:
+      "allows you to control what to do when the user changes the value of the component",
+  },
+  onFocus: {
+    description:
+      "allows you to control what to do when the onfocus event occurs.",
+  },
   options: {
     description:
       "(array): shall be designed to accept an array of objects with a predetermined structure.",
+  },
+  placeholder: {
+    description: "text to display in the text field whenever it is empty",
+  },
+  readOnly: {
+    description:
+      "makes the input field non-editable, but still allows the user to select options from the dropdown",
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
+  required: {
+    description: "defines if the field is required or not",
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
+  size: {
+    options: sizes,
+    control: { type: "select" },
+    description: "defines the size of the component",
+  },
+  value: {
+    description:
+      "string value that should be controlled by the controlling parent.",
   },
 };
 

--- a/src/Select/stories/Select.stories.tsx
+++ b/src/Select/stories/Select.stories.tsx
@@ -22,6 +22,12 @@ const options = [
   { id: "per", label: "Peru", value: "peru" },
 ];
 
+const manyOptions = Array.from({ length: 20 }, (_, i) => ({
+  id: `option-${i + 1}`,
+  label: `Option ${i + 1}`,
+  value: `option-${i + 1}`,
+}));
+
 const Default = (args: ISelect) => <SelectController {...args} />;
 
 Default.args = {
@@ -35,8 +41,25 @@ Default.args = {
   required: false,
   size: "wide",
   fullwidth: false,
+  readonly: false,
+};
+
+const WithManyOptions = (args: ISelect) => <SelectController {...args} />;
+
+WithManyOptions.args = {
+  label: "Many Options",
+  name: "manyOptions",
+  id: "manyOptionsId",
+  placeholder: "Select an option",
+  value: "",
+  disabled: false,
+  options: manyOptions,
+  required: false,
+  size: "wide",
+  fullwidth: false,
+  maxItems: 5,
+  readonly: false,
 };
 
 export default story;
-
-export { Default };
+export { Default, WithManyOptions };


### PR DESCRIPTION
This pull request introduces a new `readOnly` prop to the component, enabling better control over user interaction with the inner TextField. When the `readOnly` prop is set to true, it prevents users from typing into the TextField, making it read-only. This enhancement is useful in scenarios where the field should display data without allowing modification by the user.